### PR TITLE
Fix README docker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ What you now have to do before you start the microservice is to place additional
 
 * [Getting Started & Documentation](https://kit-data-manager.github.io/webpage/base-repo/index.html)
 * [API documentation](https://kit-data-manager.github.io/webpage/base-repo/documentation/api-docs.html)
-* [Docker container](https://github.com/kit-data-manager/base-repo/pkgs/container/base-repo/base-repo)
+* [Docker container](https://github.com/kit-data-manager/base-repo/pkgs/container/base-repo)
 * [Information about the DataCite metadata schema](https://schema.datacite.org/)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ What you now have to do before you start the microservice is to place additional
 
 * [Getting Started & Documentation](https://kit-data-manager.github.io/webpage/base-repo/index.html)
 * [API documentation](https://kit-data-manager.github.io/webpage/base-repo/documentation/api-docs.html)
-* [Docker container](https://github.com/kit-data-manager/base-repo/pkgs/container/base-repo%2Fbase-repo)
+* [Docker container](https://github.com/kit-data-manager/base-repo/pkgs/container/base-repo/base-repo)
 * [Information about the DataCite metadata schema](https://schema.datacite.org/)
 
 ## License


### PR DESCRIPTION
Link initially contained an escaped slash, resulting in a 404 error
Afaik package has been moved from base-repo/base-repo to base-repo. Link reflects that now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Fixed Docker container links in README by removing URL-encoded segments (base-repo%2Fbase-repo → base-repo) in Getting Started and More Information sections.
  * Improves readability and ensures links resolve correctly when navigating setup resources.
  * Clarifies setup guidance for new users.
  * No changes to functionality, configuration, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->