### PR TITLE
Fix link to Docker images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ What you now have to do before you start the microservice is to place additional
 
 * [Getting Started & Documentation](https://kit-data-manager.github.io/webpage/base-repo/index.html)
 * [API documentation](https://kit-data-manager.github.io/webpage/base-repo/documentation/api-docs.html)
-* [Docker container](https://github.com/kit-data-manager/base-repo/pkgs/container/base-repo%2Fbase-repo)
+* [Docker container](https://github.com/kit-data-manager/base-repo/pkgs/container/base-repo)
 * [Information about the DataCite metadata schema](https://schema.datacite.org/)
 
 ## License


### PR DESCRIPTION
Fix: package structure was changed, link to package is outdated and leads to 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker container URL formatting in README for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->